### PR TITLE
Add an KafkaAdminService for consuming monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ For further reference, please consider the following sections:
 * [Prometheus](https://docs.spring.io/spring-boot/docs/3.3.0/reference/htmlsingle/index.html#actuator.metrics.export.prometheus)
 
 
+## Contact
+
+### For NAV employees
+
+We are available at the Slack channel `#esyfo`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# sykepengedager-informasjon
+
+Core functions of this application:
+
+1. Listens to topics: Monitors the **aap.sykepengedager.infotrygd.v1** and **tbd.utbetaling** topics, capturing payments data for storage in the database.
+2. Serves data via REST endpoints: Provides access to the maximum date and other relevant data like "gjenstaende_sykedager" or creation date through RESTful API endpoints.
+3. Writes data to topic: Publishes the maximum date and other relevant information like "gjenstaende_sykedager" or creation date to the **InsertNameHere** topic. // TODO
+
+## Technologies used
+
+* Docker
+* Gradle
+* Kafka
+* Kotlin
+* Spring Boot
+* Postgres
+
+
+### Test
+Run test: `./gradlew  test`
+
+### Reference Documentation
+For further reference, please consider the following sections:
+
+* [Official Gradle documentation](https://docs.gradle.org)
+* [Spring Boot Gradle Plugin Reference Guide](https://docs.spring.io/spring-boot/docs/3.3.0/gradle-plugin/reference/html/)
+* [Create an OCI image](https://docs.spring.io/spring-boot/docs/3.3.0/gradle-plugin/reference/html/#build-image)
+* [Spring Boot DevTools](https://docs.spring.io/spring-boot/docs/3.3.0/reference/htmlsingle/index.html#using.devtools)
+* [Flyway Migration](https://docs.spring.io/spring-boot/docs/3.3.0/reference/htmlsingle/index.html#howto.data-initialization.migration-tool.flyway)
+* [Spring for Apache Kafka](https://docs.spring.io/spring-boot/docs/3.3.0/reference/htmlsingle/index.html#messaging.kafka)
+* [Prometheus](https://docs.spring.io/spring-boot/docs/3.3.0/reference/htmlsingle/index.html#actuator.metrics.export.prometheus)
+
+

--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -16,6 +16,8 @@ exceptions:
 complexity:
   LongMethod:
     active: false
+  NestedBlockDepth:
+    active: false
 config:
   validation: true
   warningsAsErrors: true

--- a/src/main/kotlin/no/nav/syfo/Application.kt
+++ b/src/main/kotlin/no/nav/syfo/Application.kt
@@ -2,8 +2,10 @@ package no.nav.syfo
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class Application
 
 @Suppress("SpreadOperator")

--- a/src/main/kotlin/no/nav/syfo/config/kafka/AivenKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/config/kafka/AivenKafkaConfig.kt
@@ -3,6 +3,7 @@
 package no.nav.syfo.config.kafka
 
 import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.consumer.Consumer
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -64,5 +65,19 @@ class AivenKafkaConfig(
         factory.setCommonErrorHandler(aivenKafkaErrorHandler)
         factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
         return factory
+    }
+
+    @Bean
+    fun kafkaSykepengedagerInformasjonConsumer(
+        kafkaListenerContainerFactory: ConcurrentKafkaListenerContainerFactory<String, String>
+    ): Consumer<String, String> {
+        val consumerFactory = kafkaListenerContainerFactory.consumerFactory
+        val consumerProps = consumerFactory.configurationProperties
+
+        return DefaultKafkaConsumerFactory(
+            consumerProps,
+            StringDeserializer(),
+            StringDeserializer()
+        ).createConsumer()
     }
 }

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -33,7 +33,7 @@ class KafkaAdminService(
         log.info("[MAX_DATE_RECORDS] Created AC, about to loop topic")
 
         for (topic in listOf(topicInfotrygd, topicSpleis)) {
-            log.info("[MAX_DATE_RECORDS] Start to estimate remaining records to consume")
+            log.info("[MAX_DATE_RECORDS] Start to estimate remaining records to consume from $topic")
             adminClient.use { client ->
                 val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topic)
                     .map { TopicPartition(it.topic(), it.partition()) }

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -50,9 +50,6 @@ class KafkaAdminService(
                     val currentOffset = currentOffsets[partition]?.offset() ?: 0
                     val endOffset = endOffsets[partition]?.offset() ?: 0
                     val recordsToConsume = endOffset - currentOffset
-
-                    log.info("[MAX_DATE_RECORDS] Partition: $partition, Records to consume: $recordsToConsume")
-
                     totalRecordsToConsume += recordsToConsume
                     totalUnconsumedRecords += if (recordsToConsume > 0) recordsToConsume else 0
                 }
@@ -89,38 +86,27 @@ class KafkaAdminService(
 
                 val allConsumed = totalRecordsToConsume == 0L
 
-                if (allConsumed) {
+                /*if (allConsumed) {
                     log.info("[MAX_DATE_RECORDS] All data from topic $topic is consumed.")
                 } else {
                     log.info("[MAX_DATE_RECORDS] There is still data to be consumed from topic $topic.")
-                }
+                }*/
             }
         }
     }
 
     private fun measureConsumptionRate(topic: String, kafkaConsumer: Consumer<String, String>): Double {
-        val testRecords = 100L // Number of records to consume for testing
+        val testRecords = 3L // Number of records to consume for testing
 
         val testPartition = kafkaConsumer.partitionsFor(topic).first()
-        log.info(
-            "[MAX_DATE_RECORDS] measureConsumptionRate 1 testPartition.partition():" +
-                " ${testPartition.partition()},,, ${testPartition.topic()}"
-        )
-
         val startTime = System.currentTimeMillis()
 
         kafkaConsumer.assign(listOf(TopicPartition(testPartition.topic(), testPartition.partition())))
         var consumedRecords = 0L
 
-        log.info("[MAX_DATE_RECORDS] measureConsumptionRate 2 $topic")
-
         while (consumedRecords < testRecords) {
-            log.info("[MAX_DATE_RECORDS] measureConsumptionRate  4 consumedRecords $consumedRecords $topic")
-
-            val records = kafkaConsumer.poll(Duration.ofMillis(100))
-            log.info("[MAX_DATE_RECORDS] measureConsumptionRate  polled records ${records.count()} $topic")
+            val records = kafkaConsumer.poll(Duration.ofMillis(3))
             if (records.count() > 0) {
-                log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 records count ${records.count()} $topic")
                 consumedRecords += records.count()
             } else {
                 break
@@ -129,7 +115,10 @@ class KafkaAdminService(
 
         val endTime = System.currentTimeMillis()
         val consumptionTimeMillis = endTime - startTime
-        log.info("[MAX_DATE_RECORDS] measureConsumptionRate 5 consumedRecords ${consumedRecords.toDouble()}  $topic")
+        log.info(
+            "[MAX_DATE_RECORDS] measureConsumptionRate  during test ${consumedRecords.toDouble()}  " +
+                "from topic $topic"
+        )
 
         return consumedRecords.toDouble() / consumptionTimeMillis
     }

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -165,7 +165,7 @@ class KafkaAdminService(
 
         val endTime = System.currentTimeMillis()
         val consumptionTimeMillis = endTime - startTime
-        log.info("[MAX_DATE_RECORDS] measureConsumptionRate 5 $topic")
+        log.info("[MAX_DATE_RECORDS] measureConsumptionRate 5 consumedRecords ${consumedRecords.toDouble()}  $topic")
 
         return consumedRecords.toDouble() / consumptionTimeMillis
     }

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -96,7 +96,8 @@ class KafkaAdminService(
 
         val testPartition = kafkaConsumer.partitionsFor(topic).first()
         log.info(
-            "[MAX_DATE_RECORDS] measureConsumptionRate 1 testPartition.partition(): ${testPartition.partition()},,, ${testPartition.topic()}"
+            "[MAX_DATE_RECORDS] measureConsumptionRate 1 testPartition.partition():" +
+                " ${testPartition.partition()},,, ${testPartition.topic()}"
         )
 
         val startTime = System.currentTimeMillis()

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -37,6 +37,7 @@ class KafkaAdminService(
                 val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topic)
                     .map { TopicPartition(it.topic(), it.partition()) }
                     .toSet()
+                kafkaSykepengedagerInformasjonConsumer.seekToBeginning(partitions)
 
                 val currentOffsets = kafkaSykepengedagerInformasjonConsumer.committed(partitions)
                 val endOffsets = client.listOffsets(

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -84,7 +84,7 @@ class KafkaAdminService(
                     )
                 }
 
-                val allConsumed = totalRecordsToConsume == 0L
+//                val allConsumed = totalRecordsToConsume == 0L
 
                 /*if (allConsumed) {
                     log.info("[MAX_DATE_RECORDS] All data from topic $topic is consumed.")
@@ -106,6 +106,9 @@ class KafkaAdminService(
 
         while (consumedRecords < testRecords) {
             val records = kafkaConsumer.poll(Duration.ofMillis(3))
+            log.info(
+                "[MAX_DATE_RECORDS] Polled records $records in $topic topic"
+            )
             if (records.count() > 0) {
                 consumedRecords += records.count()
             } else {

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -155,7 +155,7 @@ class KafkaAdminService(
             log.info("[MAX_DATE_RECORDS] measureConsumptionRate  4 consumedRecords $consumedRecords $topic")
 
             val records = kafkaConsumer.poll(Duration.ofMillis(100))
-            log.info("[MAX_DATE_RECORDS] measureConsumptionRate  polled records $records $topic")
+            log.info("[MAX_DATE_RECORDS] measureConsumptionRate  polled records ${records.count()} $topic")
             if (records.count() > 0) {
                 log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 records count ${records.count()} $topic")
                 consumedRecords += records.count()

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -32,7 +32,7 @@ class KafkaAdminService(
         val adminClient = AdminClient.create(kafkaAdmin.configurationProperties + commonConfig)
 
         for (topic in listOf(topicInfotrygd, topicSpleis)) {
-            log.info("[MAX_DATE_RECORDS] Start to estimate remaining records to consume from $topic")
+            log.info("[MAX_DATE_RECORDS1] Start to estimate remaining records to consume from $topic")
             adminClient.use { client ->
                 val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topic)
                     .map { TopicPartition(it.topic(), it.partition()) }
@@ -54,9 +54,9 @@ class KafkaAdminService(
                     totalUnconsumedRecords += if (recordsToConsume > 0) recordsToConsume else 0
                 }
 
-                log.info("[MAX_DATE_RECORDS] Total partitions: ${partitions.size}")
-                log.info("[MAX_DATE_RECORDS] Total records to consume: $totalRecordsToConsume")
-                log.info("[MAX_DATE_RECORDS] Total unconsumed records: $totalUnconsumedRecords")
+                log.info("[MAX_DATE_RECORDS1] Total partitions: ${partitions.size}")
+                log.info("[MAX_DATE_RECORDS1] Total records to consume: $totalRecordsToConsume")
+                log.info("[MAX_DATE_RECORDS1] Total unconsumed records: $totalUnconsumedRecords")
 
                 if (partitions.isNotEmpty()) {
                     // Measure consumption rate
@@ -72,24 +72,24 @@ class KafkaAdminService(
                         val estimatedTimeHours = estimatedTimeMinutes / 60
 
                         log.info(
-                            "[MAX_DATE_RECORDS] Estimated time to consume remaining records from topic $topic:" +
+                            "[MAX_DATE_RECORDS1] Estimated time to consume remaining records from topic $topic:" +
                                 " $estimatedTimeHours hours"
                         )
                     } else {
-                        log.info("[MAX_DATE_RECORDS] consumptionRate of topic $topic is 0.")
+                        log.info("[MAX_DATE_RECORDS1] consumptionRate of topic $topic is 0.")
                     }
                 } else {
                     log.info(
-                        "[MAX_DATE_RECORDS] There are 0 partitions in $topic topic"
+                        "[MAX_DATE_RECORDS1] There are 0 partitions in $topic topic"
                     )
                 }
 
 //                val allConsumed = totalRecordsToConsume == 0L
 
                 /*if (allConsumed) {
-                    log.info("[MAX_DATE_RECORDS] All data from topic $topic is consumed.")
+                    log.info("[MAX_DATE_RECORDS1] All data from topic $topic is consumed.")
                 } else {
-                    log.info("[MAX_DATE_RECORDS] There is still data to be consumed from topic $topic.")
+                    log.info("[MAX_DATE_RECORDS1] There is still data to be consumed from topic $topic.")
                 }*/
             }
         }
@@ -107,7 +107,7 @@ class KafkaAdminService(
         while (consumedRecords < testRecords) {
             val records = kafkaConsumer.poll(Duration.ofMillis(3))
             log.info(
-                "[MAX_DATE_RECORDS] Polled records $records in $topic topic"
+                "[MAX_DATE_RECORDS1] Polled records $records in $topic topic"
             )
             if (records.count() > 0) {
                 consumedRecords += records.count()
@@ -119,7 +119,7 @@ class KafkaAdminService(
         val endTime = System.currentTimeMillis()
         val consumptionTimeMillis = endTime - startTime
         log.info(
-            "[MAX_DATE_RECORDS] measureConsumptionRate  during test ${consumedRecords.toDouble()}  " +
+            "[MAX_DATE_RECORDS1] measureConsumptionRate  during test ${consumedRecords.toDouble()}  " +
                 "from topic $topic"
         )
 

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -27,7 +27,7 @@ class KafkaAdminService(
 
     val commonConfig = avienKafkaConfig.commonConfig()
 
-    @Scheduled(fixedRate = 60000) // Runs every 60 seconds
+    @Scheduled(fixedRate = 60 * 60 * 1000) // Runs every 60 minutes
     fun run() {
         val adminClient = AdminClient.create(kafkaAdmin.configurationProperties + commonConfig)
 

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -155,6 +155,7 @@ class KafkaAdminService(
             log.info("[MAX_DATE_RECORDS] measureConsumptionRate  4 consumedRecords $consumedRecords $topic")
 
             val records = kafkaConsumer.poll(Duration.ofMillis(100))
+            log.info("[MAX_DATE_RECORDS] measureConsumptionRate  polled records $records $topic")
             if (records.count() > 0) {
                 log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 records count ${records.count()} $topic")
                 consumedRecords += records.count()

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -61,23 +61,30 @@ class KafkaAdminService(
                 log.info("[MAX_DATE_RECORDS] Total records to consume: $totalRecordsToConsume")
                 log.info("[MAX_DATE_RECORDS] Total unconsumed records: $totalUnconsumedRecords")
 
-                // Measure consumption rate
-                val consumptionRate = measureConsumptionRate(topic, kafkaSykepengedagerInformasjonConsumer)
+                if (partitions.isNotEmpty()) {
+                    // Measure consumption rate
+                    val consumptionRate = measureConsumptionRate(topic, kafkaSykepengedagerInformasjonConsumer)
 
-                if (consumptionRate > 0) {
-                    // Estimate time to consume remaining records (in milliseconds)
-                    val estimatedTimeMillis = totalUnconsumedRecords / consumptionRate * 1000
+                    if (consumptionRate > 0) {
+                        // Estimate time to consume remaining records (in milliseconds)
+                        val estimatedTimeMillis = totalUnconsumedRecords / consumptionRate * 1000
 
-                    // Convert milliseconds to a human-readable format
-                    val estimatedTimeSeconds = estimatedTimeMillis / 1000
-                    val estimatedTimeMinutes = estimatedTimeSeconds / 60
-                    val estimatedTimeHours = estimatedTimeMinutes / 60
+                        // Convert milliseconds to a human-readable format
+                        val estimatedTimeSeconds = estimatedTimeMillis / 1000
+                        val estimatedTimeMinutes = estimatedTimeSeconds / 60
+                        val estimatedTimeHours = estimatedTimeMinutes / 60
 
-                    log.info(
-                        "Estimated time to consume remaining records from topic $topic: $estimatedTimeHours hours"
-                    )
+                        log.info(
+                            "[MAX_DATE_RECORDS] Estimated time to consume remaining records from topic $topic:" +
+                                " $estimatedTimeHours hours"
+                        )
+                    } else {
+                        log.info("[MAX_DATE_RECORDS] consumptionRate of topic $topic is 0.")
+                    }
                 } else {
-                    log.info("[MAX_DATE_RECORDS] consumptionRate of topic $topic is 0.")
+                    log.info(
+                        "[MAX_DATE_RECORDS] There are 0 partitions in $topic topic"
+                    )
                 }
 
                 val allConsumed = totalRecordsToConsume == 0L

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -155,8 +155,12 @@ class KafkaAdminService(
             log.info("[MAX_DATE_RECORDS] measureConsumptionRate  4 consumedRecords $consumedRecords $topic")
 
             val records = kafkaConsumer.poll(Duration.ofMillis(100))
-            log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 records count ${records.count()} $topic")
-            consumedRecords += records.count()
+            if (records.count() > 0) {
+                log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 records count ${records.count()} $topic")
+                consumedRecords += records.count()
+            } else {
+                break
+            }
         }
 
         val endTime = System.currentTimeMillis()

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -1,0 +1,104 @@
+package no.nav.syfo.kafka.admin
+
+import no.nav.syfo.config.kafka.topicSykepengedagerInfotrygd
+import no.nav.syfo.config.kafka.topicUtbetaling
+import no.nav.syfo.logger
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.OffsetSpec
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.common.TopicPartition
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.core.KafkaAdmin
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+@Service
+@Profile("remote")
+class KafkaAdminService(
+    private val kafkaSykepengedagerInformasjonConsumer: Consumer<String, String>,
+    private val kafkaAdmin: KafkaAdmin
+) {
+    private val log = logger()
+    private val topicInfotrygd = topicSykepengedagerInfotrygd
+    private val topicSpleis = topicUtbetaling
+
+    @Scheduled(fixedRate = 60000) // Runs every 60 seconds
+    fun run() {
+        val adminClient = AdminClient.create(kafkaAdmin.configurationProperties)
+
+        for (topic in listOf(topicInfotrygd, topicSpleis)) {
+            adminClient.use { client ->
+                val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topic)
+                    .map { TopicPartition(it.topic(), it.partition()) }
+                    .toSet()
+
+                val currentOffsets = kafkaSykepengedagerInformasjonConsumer.committed(partitions)
+                val endOffsets = client.listOffsets(
+                    partitions.associateWith { OffsetSpec.latest() }
+                ).all().get()
+
+                var totalRecordsToConsume = 0L
+                var totalUnconsumedRecords = 0L
+
+                partitions.forEach { partition ->
+                    val currentOffset = currentOffsets[partition]?.offset() ?: 0
+                    val endOffset = endOffsets[partition]?.offset() ?: 0
+                    val recordsToConsume = endOffset - currentOffset
+
+                    log.info("[MAX_DATE_RECORDS] Partition: $partition, Records to consume: $recordsToConsume")
+
+                    totalRecordsToConsume += recordsToConsume
+                    totalUnconsumedRecords += if (recordsToConsume > 0) recordsToConsume else 0
+                }
+
+                log.info("[MAX_DATE_RECORDS] Total partitions: ${partitions.size}")
+                log.info("[MAX_DATE_RECORDS] Total records to consume: $totalRecordsToConsume")
+                log.info("[MAX_DATE_RECORDS] Total unconsumed records: $totalUnconsumedRecords")
+
+                // Measure consumption rate
+                val consumptionRate = measureConsumptionRate(topic, kafkaSykepengedagerInformasjonConsumer)
+
+                // Estimate time to consume remaining records (in milliseconds)
+                val estimatedTimeMillis = totalUnconsumedRecords / consumptionRate * 1000
+
+                // Convert milliseconds to a human-readable format
+                val estimatedTimeSeconds = estimatedTimeMillis / 1000
+                val estimatedTimeMinutes = estimatedTimeSeconds / 60
+                val estimatedTimeHours = estimatedTimeMinutes / 60
+
+                log.info(
+                    "Estimated time to consume remaining records from topic $topic: $estimatedTimeHours hours"
+                )
+
+                val allConsumed = totalRecordsToConsume == 0L
+
+                if (allConsumed) {
+                    log.info("[MAX_DATE_RECORDS] All data from topic $topic is consumed.")
+                } else {
+                    log.info("[MAX_DATE_RECORDS] There is still data to be consumed from topic $topic.")
+                }
+            }
+        }
+    }
+
+    private fun measureConsumptionRate(topic: String, kafkaConsumer: Consumer<String, String>): Double {
+        val testRecords = 100L // Number of records to consume for testing
+        val testPartition = kafkaConsumer.partitionsFor(topic).first()
+
+        val startTime = System.currentTimeMillis()
+
+        kafkaConsumer.assign(listOf(TopicPartition(testPartition.topic(), testPartition.partition())))
+        var consumedRecords = 0L
+
+        while (consumedRecords < testRecords) {
+            val records = kafkaConsumer.poll(Duration.ofMillis(100))
+            consumedRecords += records.count()
+        }
+
+        val endTime = System.currentTimeMillis()
+        val consumptionTimeMillis = endTime - startTime
+
+        return consumedRecords.toDouble() / consumptionTimeMillis
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -152,9 +152,10 @@ class KafkaAdminService(
         log.info("[MAX_DATE_RECORDS] measureConsumptionRate 2 $topic")
 
         while (consumedRecords < testRecords) {
-            log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 $topic")
+            log.info("[MAX_DATE_RECORDS] measureConsumptionRate  4 consumedRecords $consumedRecords $topic")
 
             val records = kafkaConsumer.poll(Duration.ofMillis(100))
+            log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 records count ${records.count()} $topic")
             consumedRecords += records.count()
         }
 

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -139,21 +139,28 @@ class KafkaAdminService(
     }
 
     private fun measureConsumptionRate(topic: String, kafkaConsumer: Consumer<String, String>): Double {
+        log.info("[MAX_DATE_RECORDS] measureConsumptionRate $topic")
         val testRecords = 100L // Number of records to consume for testing
         val testPartition = kafkaConsumer.partitionsFor(topic).first()
+        log.info("[MAX_DATE_RECORDS] measureConsumptionRate 1 $topic")
 
         val startTime = System.currentTimeMillis()
 
         kafkaConsumer.assign(listOf(TopicPartition(testPartition.topic(), testPartition.partition())))
         var consumedRecords = 0L
 
+        log.info("[MAX_DATE_RECORDS] measureConsumptionRate 2 $topic")
+
         while (consumedRecords < testRecords) {
+            log.info("[MAX_DATE_RECORDS] measureConsumptionRate 4 $topic")
+
             val records = kafkaConsumer.poll(Duration.ofMillis(100))
             consumedRecords += records.count()
         }
 
         val endTime = System.currentTimeMillis()
         val consumptionTimeMillis = endTime - startTime
+        log.info("[MAX_DATE_RECORDS] measureConsumptionRate 5 $topic")
 
         return consumedRecords.toDouble() / consumptionTimeMillis
     }

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -30,60 +30,110 @@ class KafkaAdminService(
     @Scheduled(fixedRate = 60000) // Runs every 60 seconds
     fun run() {
         val adminClient = AdminClient.create(kafkaAdmin.configurationProperties + commonConfig)
-        log.info("[MAX_DATE_RECORDS] Created AC, about to loop topic")
 
-        for (topic in listOf(topicInfotrygd, topicSpleis)) {
-            log.info("[MAX_DATE_RECORDS] Start to estimate remaining records to consume from $topic")
-            adminClient.use { client ->
-                val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topic)
-                    .map { TopicPartition(it.topic(), it.partition()) }
-                    .toSet()
+        log.info("[MAX_DATE_RECORDS] Start to estimate remaining records to consume from $topicSpleis")
+        adminClient.use { client ->
+            val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topicSpleis)
+                .map { TopicPartition(it.topic(), it.partition()) }
+                .toSet()
 
-                val currentOffsets = kafkaSykepengedagerInformasjonConsumer.committed(partitions)
-                val endOffsets = client.listOffsets(
-                    partitions.associateWith { OffsetSpec.latest() }
-                ).all().get()
+            val currentOffsets = kafkaSykepengedagerInformasjonConsumer.committed(partitions)
+            val endOffsets = client.listOffsets(
+                partitions.associateWith { OffsetSpec.latest() }
+            ).all().get()
 
-                var totalRecordsToConsume = 0L
-                var totalUnconsumedRecords = 0L
+            var totalRecordsToConsume = 0L
+            var totalUnconsumedRecords = 0L
 
-                partitions.forEach { partition ->
-                    val currentOffset = currentOffsets[partition]?.offset() ?: 0
-                    val endOffset = endOffsets[partition]?.offset() ?: 0
-                    val recordsToConsume = endOffset - currentOffset
+            partitions.forEach { partition ->
+                val currentOffset = currentOffsets[partition]?.offset() ?: 0
+                val endOffset = endOffsets[partition]?.offset() ?: 0
+                val recordsToConsume = endOffset - currentOffset
 
-                    log.info("[MAX_DATE_RECORDS] Partition: $partition, Records to consume: $recordsToConsume")
+                log.info("[MAX_DATE_RECORDS] Partition: $partition, Records to consume: $recordsToConsume")
 
-                    totalRecordsToConsume += recordsToConsume
-                    totalUnconsumedRecords += if (recordsToConsume > 0) recordsToConsume else 0
-                }
+                totalRecordsToConsume += recordsToConsume
+                totalUnconsumedRecords += if (recordsToConsume > 0) recordsToConsume else 0
+            }
 
-                log.info("[MAX_DATE_RECORDS] Total partitions: ${partitions.size}")
-                log.info("[MAX_DATE_RECORDS] Total records to consume: $totalRecordsToConsume")
-                log.info("[MAX_DATE_RECORDS] Total unconsumed records: $totalUnconsumedRecords")
+            log.info("[MAX_DATE_RECORDS] Total partitions: ${partitions.size}")
+            log.info("[MAX_DATE_RECORDS] Total records to consume: $totalRecordsToConsume")
+            log.info("[MAX_DATE_RECORDS] Total unconsumed records: $totalUnconsumedRecords")
 
-                // Measure consumption rate
-                val consumptionRate = measureConsumptionRate(topic, kafkaSykepengedagerInformasjonConsumer)
+            // Measure consumption rate
+            val consumptionRate = measureConsumptionRate(topicSpleis, kafkaSykepengedagerInformasjonConsumer)
 
-                // Estimate time to consume remaining records (in milliseconds)
-                val estimatedTimeMillis = totalUnconsumedRecords / consumptionRate * 1000
+            // Estimate time to consume remaining records (in milliseconds)
+            val estimatedTimeMillis = totalUnconsumedRecords / consumptionRate * 1000
 
-                // Convert milliseconds to a human-readable format
-                val estimatedTimeSeconds = estimatedTimeMillis / 1000
-                val estimatedTimeMinutes = estimatedTimeSeconds / 60
-                val estimatedTimeHours = estimatedTimeMinutes / 60
+            // Convert milliseconds to a human-readable format
+            val estimatedTimeSeconds = estimatedTimeMillis / 1000
+            val estimatedTimeMinutes = estimatedTimeSeconds / 60
+            val estimatedTimeHours = estimatedTimeMinutes / 60
 
-                log.info(
-                    "Estimated time to consume remaining records from topic $topic: $estimatedTimeHours hours"
-                )
+            log.info(
+                "Estimated time to consume remaining records from topic $topicSpleis: $estimatedTimeHours hours"
+            )
 
-                val allConsumed = totalRecordsToConsume == 0L
+            val allConsumed = totalRecordsToConsume == 0L
 
-                if (allConsumed) {
-                    log.info("[MAX_DATE_RECORDS] All data from topic $topic is consumed.")
-                } else {
-                    log.info("[MAX_DATE_RECORDS] There is still data to be consumed from topic $topic.")
-                }
+            if (allConsumed) {
+                log.info("[MAX_DATE_RECORDS] All data from topic $topicSpleis is consumed.")
+            } else {
+                log.info("[MAX_DATE_RECORDS] There is still data to be consumed from topic $topicSpleis.")
+            }
+        }
+
+        log.info("[MAX_DATE_RECORDS] Start to estimate remaining records to consume from $topicInfotrygd")
+        adminClient.use { client ->
+            val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topicInfotrygd)
+                .map { TopicPartition(it.topic(), it.partition()) }
+                .toSet()
+
+            val currentOffsets = kafkaSykepengedagerInformasjonConsumer.committed(partitions)
+            val endOffsets = client.listOffsets(
+                partitions.associateWith { OffsetSpec.latest() }
+            ).all().get()
+
+            var totalRecordsToConsume = 0L
+            var totalUnconsumedRecords = 0L
+
+            partitions.forEach { partition ->
+                val currentOffset = currentOffsets[partition]?.offset() ?: 0
+                val endOffset = endOffsets[partition]?.offset() ?: 0
+                val recordsToConsume = endOffset - currentOffset
+
+                log.info("[MAX_DATE_RECORDS] Partition: $partition, Records to consume: $recordsToConsume")
+
+                totalRecordsToConsume += recordsToConsume
+                totalUnconsumedRecords += if (recordsToConsume > 0) recordsToConsume else 0
+            }
+
+            log.info("[MAX_DATE_RECORDS] Total partitions: ${partitions.size}")
+            log.info("[MAX_DATE_RECORDS] Total records to consume: $totalRecordsToConsume")
+            log.info("[MAX_DATE_RECORDS] Total unconsumed records: $totalUnconsumedRecords")
+
+            // Measure consumption rate
+            val consumptionRate = measureConsumptionRate(topicInfotrygd, kafkaSykepengedagerInformasjonConsumer)
+
+            // Estimate time to consume remaining records (in milliseconds)
+            val estimatedTimeMillis = totalUnconsumedRecords / consumptionRate * 1000
+
+            // Convert milliseconds to a human-readable format
+            val estimatedTimeSeconds = estimatedTimeMillis / 1000
+            val estimatedTimeMinutes = estimatedTimeSeconds / 60
+            val estimatedTimeHours = estimatedTimeMinutes / 60
+
+            log.info(
+                "Estimated time to consume remaining records from topic $topicInfotrygd: $estimatedTimeHours hours"
+            )
+
+            val allConsumed = totalRecordsToConsume == 0L
+
+            if (allConsumed) {
+                log.info("[MAX_DATE_RECORDS] All data from topic $topicInfotrygd is consumed.")
+            } else {
+                log.info("[MAX_DATE_RECORDS] There is still data to be consumed from topic $topicInfotrygd.")
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -32,7 +32,7 @@ class KafkaAdminService(
         val adminClient = AdminClient.create(kafkaAdmin.configurationProperties + commonConfig)
 
         for (topic in listOf(topicInfotrygd, topicSpleis)) {
-            log.info("[MAX_DATE_RECORDS1] Start to estimate remaining records to consume from $topic")
+            log.info("[MAX_DATE_RECORDS2] Start to estimate remaining records to consume from $topic")
             adminClient.use { client ->
                 val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topic)
                     .map { TopicPartition(it.topic(), it.partition()) }
@@ -55,9 +55,9 @@ class KafkaAdminService(
                     totalUnconsumedRecords += if (recordsToConsume > 0) recordsToConsume else 0
                 }
 
-                log.info("[MAX_DATE_RECORDS1] Total partitions: ${partitions.size}")
-                log.info("[MAX_DATE_RECORDS1] Total records to consume: $totalRecordsToConsume")
-                log.info("[MAX_DATE_RECORDS1] Total unconsumed records: $totalUnconsumedRecords")
+                log.info("[MAX_DATE_RECORDS2] Total partitions: ${partitions.size}")
+                log.info("[MAX_DATE_RECORDS2] Total records to consume: $totalRecordsToConsume")
+                log.info("[MAX_DATE_RECORDS2] Total unconsumed records: $totalUnconsumedRecords")
 
                 if (partitions.isNotEmpty()) {
                     // Measure consumption rate
@@ -73,24 +73,24 @@ class KafkaAdminService(
                         val estimatedTimeHours = estimatedTimeMinutes / 60
 
                         log.info(
-                            "[MAX_DATE_RECORDS1] Estimated time to consume remaining records from topic $topic:" +
+                            "[MAX_DATE_RECORDS2] Estimated time to consume remaining records from topic $topic:" +
                                 " $estimatedTimeHours hours"
                         )
                     } else {
-                        log.info("[MAX_DATE_RECORDS1] consumptionRate of topic $topic is 0.")
+                        log.info("[MAX_DATE_RECORDS2] consumptionRate of topic $topic is 0.")
                     }
                 } else {
                     log.info(
-                        "[MAX_DATE_RECORDS1] There are 0 partitions in $topic topic"
+                        "[MAX_DATE_RECORDS2] There are 0 partitions in $topic topic"
                     )
                 }
 
 //                val allConsumed = totalRecordsToConsume == 0L
 
                 /*if (allConsumed) {
-                    log.info("[MAX_DATE_RECORDS1] All data from topic $topic is consumed.")
+                    log.info("[MAX_DATE_RECORDS2] All data from topic $topic is consumed.")
                 } else {
-                    log.info("[MAX_DATE_RECORDS1] There is still data to be consumed from topic $topic.")
+                    log.info("[MAX_DATE_RECORDS2] There is still data to be consumed from topic $topic.")
                 }*/
             }
         }
@@ -108,7 +108,7 @@ class KafkaAdminService(
         while (consumedRecords < testRecords) {
             val records = kafkaConsumer.poll(Duration.ofMillis(3))
             log.info(
-                "[MAX_DATE_RECORDS1] Polled records $records in $topic topic"
+                "[MAX_DATE_RECORDS2] Polled records $records in $topic topic"
             )
             if (records.count() > 0) {
                 consumedRecords += records.count()
@@ -120,7 +120,7 @@ class KafkaAdminService(
         val endTime = System.currentTimeMillis()
         val consumptionTimeMillis = endTime - startTime
         log.info(
-            "[MAX_DATE_RECORDS1] measureConsumptionRate  during test ${consumedRecords.toDouble()}  " +
+            "[MAX_DATE_RECORDS2] measureConsumptionRate  during test ${consumedRecords.toDouble()}  " +
                 "from topic $topic"
         )
 

--- a/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/admin/KafkaAdminService.kt
@@ -37,7 +37,8 @@ class KafkaAdminService(
                 val partitions = kafkaSykepengedagerInformasjonConsumer.partitionsFor(topic)
                     .map { TopicPartition(it.topic(), it.partition()) }
                     .toSet()
-                kafkaSykepengedagerInformasjonConsumer.seekToBeginning(partitions)
+                val partitions2 = kafkaSykepengedagerInformasjonConsumer.assignment()
+                kafkaSykepengedagerInformasjonConsumer.seekToBeginning(partitions2)
 
                 val currentOffsets = kafkaSykepengedagerInformasjonConsumer.committed(partitions)
                 val endOffsets = client.listOffsets(


### PR DESCRIPTION
Added an `KafkaAdminService` for monitoring of how many records were consumed vs remained which runs every hour.