### PR TITLE
Add missing ackMode

### DIFF
--- a/src/main/kotlin/no/nav/syfo/config/kafka/AivenKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/config/kafka/AivenKafkaConfig.kt
@@ -97,10 +97,14 @@ class AivenKafkaConfig(
     }
 
     @Bean
-    fun infotrygdKafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, String> {
+    fun infotrygdKafkaListenerContainerFactory(
+        aivenKafkaErrorHandler: AivenKafkaErrorHandler,
+    ): ConcurrentKafkaListenerContainerFactory<String, String> {
         val factory =
             ConcurrentKafkaListenerContainerFactory<String, String>()
         factory.consumerFactory = infotrygdConsumerFactory()
+        factory.setCommonErrorHandler(aivenKafkaErrorHandler)
+        factory.containerProperties.ackMode = ContainerProperties.AckMode.MANUAL_IMMEDIATE
         return factory
     }
 }


### PR DESCRIPTION
Fix for 
`Caused by: org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException: Could not resolve method parameter at index 1 in public void no.nav.syfo.kafka.consumers.spleis.SykepengedagerInformasjonKafkaConsumer.listenTopicSykepengedagerInfotrygd(org.apache.kafka.clients.consumer.ConsumerRecord<java.lang.String, java.lang.String>,org.springframework.kafka.support.Acknowledgment): 1 error(s): [Error in object 'ack': codes []; arguments []; default message [Payload value must not be empty]] 
	at org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver.resolveArgument(PayloadMethodArgumentResolver.java:128)`