### PR TITLE
Add own select for kafka producer

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kafka/producers/SykepengedagerInformasjonKafkaService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/producers/SykepengedagerInformasjonKafkaService.kt
@@ -14,7 +14,7 @@ class SykepengedagerInformasjonKafkaService(
     val log = logger()
 
     private fun getEventDTO(fnr: String): KSykepengedagerInformasjonDTO {
-        val maksDato = utbetalingerDAO.fetchMaksDatoByFnr(fnr)
+        val maksDato = utbetalingerDAO.fetchMaksDatoByFnrForKafka(fnr)
 
         return if (maksDato != null) {
             KSykepengedagerInformasjonDTO(


### PR DESCRIPTION
This SELECT statement sorts by opprettet field, which is the same as time we have receieved en event.  Should fix the issue. 
Sending event as is is more complex, because we can not filter out duplicates from infotrygd queue before we store it in DB. 
This may be improved, but with regard to time, it is the fastest and easiest solution.