### PR TITLE
Process records from new topic

### DIFF
--- a/src/main/kotlin/no/nav/syfo/config/kafka/AivenKafkaConfig.kt
+++ b/src/main/kotlin/no/nav/syfo/config/kafka/AivenKafkaConfig.kt
@@ -97,7 +97,7 @@ class AivenKafkaConfig(
         val config = listenerContainerConfig().toMutableMap()
         config.remove(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
         config.remove(ConsumerConfig.GROUP_ID_CONFIG)
-        config[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "latest"
+        config[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
         config[ConsumerConfig.GROUP_ID_CONFIG] = "sykepengedager-informasjon-group-v2"
 
         return DefaultKafkaConsumerFactory(config as Map<String, Any>)

--- a/src/main/kotlin/no/nav/syfo/kafka/consumers/SykepengedagerInformasjonKafkaConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/consumers/SykepengedagerInformasjonKafkaConsumer.kt
@@ -85,10 +85,18 @@ class SykepengedagerInformasjonKafkaConsumer(
         ack: Acknowledgment,
     ) {
         try {
+            val topic = record.topic()
             log.info(
                 "Received a record with key ${record.key()} from topic $topicSykepengedagerInfotrygd",
             )
-
+            when (topic) {
+                topicSykepengedagerInfotrygd -> {
+                    log.info(
+                        "Going to process record from topicSykepengedagerInfotrygd $topic",
+                    )
+                    infotrygdRecordProcessor.processRecord(record)
+                }
+            }
             ack.acknowledge()
         } catch (e: Exception) {
             log.error("Exception in ${SykepengedagerInformasjonKafkaConsumer::class.qualifiedName}-listener: $e", e)


### PR DESCRIPTION
According to Marie-Louise : "Replikeringen til nåværende Kafka topic avsluttes når replikeringen flyttes til den nye topicen."
So i have gust added ca call to processtng data from the new topic and canged AUTO_OFFSET_RESET_CONFIG to earliest so that no messages will be missed. The new topic is already enabled in prod( autoStartup = "true" in listener). 

[Protection against duplicate inserts ](https://github.com/navikt/sykepengedager-informasjon/blob/3ce162744b7184d963eda7017dbb3825321d766b/src/main/kotlin/no/nav/syfo/kafka/recordprocessors/InfotrygdRecordProcessor.kt#L57)

After some time listener for the old topic may be deleted.
