### PR TITLE
Avoid nested catching

### DIFF
--- a/src/main/kotlin/no/nav/syfo/db/UtbetalingInfotrygdDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/db/UtbetalingInfotrygdDAO.kt
@@ -24,7 +24,7 @@ class UtbetalingInfotrygdDAO(
         utbetaltTilDate: LocalDate,
         gjenstaendeSykepengedager: Int,
         source: InfotrygdSource,
-    ): UUID? {
+    ) {
         val sql =
             """
             INSERT INTO UTBETALING_INFOTRYGD  (
@@ -56,13 +56,7 @@ class UtbetalingInfotrygdDAO(
                 .addValue("GJENSTAENDE_SYKEDAGER", gjenstaendeSykepengedager)
                 .addValue("OPPRETTET", Timestamp.valueOf(LocalDateTime.now()))
                 .addValue("SOURCE", source.name)
-        try {
-            namedParameterJdbcTemplate.update(sql, params)
-            return uuid
-        } catch (e: Exception) {
-            log.error("Could not execute insert a message for infotrygd, message: ${e.message}")
-            return null
-        }
+        namedParameterJdbcTemplate.update(sql, params)
     }
 
     fun isInfotrygdUtbetalingExists(

--- a/src/main/kotlin/no/nav/syfo/kafka/recordprocessors/InfotrygdRecordProcessor.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/recordprocessors/InfotrygdRecordProcessor.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.kafka.recordprocessors
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import no.nav.syfo.config.kafka.topicAapSykepengedagerInfotrygd
 import no.nav.syfo.db.UtbetalingInfotrygdDAO
 import no.nav.syfo.kafka.consumers.aapInfotrygd.domain.InfotrygdSource
 import no.nav.syfo.kafka.consumers.aapInfotrygd.domain.KInfotrygdSykepengedager
@@ -25,25 +24,21 @@ class InfotrygdRecordProcessor(
     private lateinit var utbetalingInfotrygdDAO: UtbetalingInfotrygdDAO
 
     fun processRecord(record: ConsumerRecord<String, String>) {
-        try {
-            val kInfotrygdSykepengedager = objectMapper.readValue(record.value(), KInfotrygdSykepengedager::class.java)
-            val fnr = kInfotrygdSykepengedager.after.F_NR
-            val sykepengerMaxDate = parseDate(kInfotrygdSykepengedager.after.MAX_DATO)
-            val utbetaltTom = kInfotrygdSykepengedager.after.UTBET_TOM
+        val kInfotrygdSykepengedager = objectMapper.readValue(record.value(), KInfotrygdSykepengedager::class.java)
+        val fnr = kInfotrygdSykepengedager.after.F_NR
+        val sykepengerMaxDate = parseDate(kInfotrygdSykepengedager.after.MAX_DATO)
+        val utbetaltTom = kInfotrygdSykepengedager.after.UTBET_TOM
 
-            if (utbetaltTom != null) {
-                val utbetaltTomDate = parseDate(utbetaltTom)
+        if (utbetaltTom != null) {
+            val utbetaltTomDate = parseDate(utbetaltTom)
 
-                processInfotrygdEvent(
-                    fnr,
-                    sykepengerMaxDate,
-                    utbetaltTomDate,
-                    utbetaltTomDate.gjenstaendeSykepengedager(sykepengerMaxDate),
-                    InfotrygdSource.AAP_KAFKA_TOPIC,
-                )
-            }
-        } catch (e: Exception) {
-            log.error("Exception in [$topicAapSykepengedagerInfotrygd]-processor: $e", e)
+            processInfotrygdEvent(
+                fnr,
+                sykepengerMaxDate,
+                utbetaltTomDate,
+                utbetaltTomDate.gjenstaendeSykepengedager(sykepengerMaxDate),
+                InfotrygdSource.AAP_KAFKA_TOPIC,
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/kafka/recordprocessors/SpleisRecordProcessor.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/recordprocessors/SpleisRecordProcessor.kt
@@ -1,13 +1,11 @@
 package no.nav.syfo.kafka.recordprocessors
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import no.nav.syfo.config.kafka.topicUtbetaling
 import no.nav.syfo.db.UtbetalingSpleisDAO
 import no.nav.syfo.kafka.consumers.spleis.domain.UTBETALING_UTBETALT
 import no.nav.syfo.kafka.consumers.spleis.domain.UTBETALING_UTEN_UTBETALING
 import no.nav.syfo.kafka.consumers.spleis.domain.UtbetalingSpleis
 import no.nav.syfo.kafka.producers.SykepengedagerInformasjonKafkaService
-import no.nav.syfo.logger
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -16,20 +14,15 @@ import org.springframework.stereotype.Component
 class SpleisRecordProcessor(
     val sykepengedagerInformasjonKafkaService: SykepengedagerInformasjonKafkaService,
 ) {
-    private val log = logger()
     private val objectMapper = jacksonObjectMapper()
 
     @Autowired
     private lateinit var utbetalingSpleisDAO: UtbetalingSpleisDAO
 
     fun processRecord(record: ConsumerRecord<String, String>) {
-        try {
-            val utbetaling = objectMapper.readValue(record.value(), UtbetalingSpleis::class.java)
-            if (utbetaling.event == UTBETALING_UTBETALT || utbetaling.event == UTBETALING_UTEN_UTBETALING) {
-                processUtbetalingSpleisEvent(utbetaling)
-            }
-        } catch (e: Exception) {
-            log.error("Exception in [$topicUtbetaling]-processor: $e", e)
+        val utbetaling = objectMapper.readValue(record.value(), UtbetalingSpleis::class.java)
+        if (utbetaling.event == UTBETALING_UTBETALT || utbetaling.event == UTBETALING_UTEN_UTBETALING) {
+            processUtbetalingSpleisEvent(utbetaling)
         }
     }
 


### PR DESCRIPTION
Avoid nested catching which causes SykepengedagerInformasjonKafkaConsumer to acknowledge unprocessed records