### PR TITLE
Use tom-date instead of utbetalt_tom in rest-api and Kafka-topic

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/SykepengerMaxDateRestApiV1.kt
+++ b/src/main/kotlin/no/nav/syfo/api/SykepengerMaxDateRestApiV1.kt
@@ -75,9 +75,9 @@ class SykepengerMaxDateRestApiV1(
             val utbetaltTom =
                 sykepengerMaxDate?.let {
                     if (isoFormat) {
-                        (it.utbetalt_tom ?: it.tom).toString()
+                        it.tom.toString()
                     } else {
-                        formatDateForLetter(it.utbetalt_tom ?: it.tom)
+                        formatDateForLetter(it.tom)
                     }
                 }
             log.info("Fetched sykepengerMaxDate from database: ${sykepengerMaxDate?.forelopig_beregnet_slutt}")

--- a/src/main/kotlin/no/nav/syfo/kafka/producers/SykepengedagerInformasjonKafkaService.kt
+++ b/src/main/kotlin/no/nav/syfo/kafka/producers/SykepengedagerInformasjonKafkaService.kt
@@ -21,7 +21,7 @@ class SykepengedagerInformasjonKafkaService(
                 id = maksDato.id,
                 personIdent = maksDato.fnr,
                 forelopigBeregnetSlutt = maksDato.forelopig_beregnet_slutt,
-                utbetaltTom = maksDato.utbetalt_tom ?: maksDato.tom,
+                utbetaltTom = maksDato.tom,
                 gjenstaendeSykedager = maksDato.gjenstaende_sykedager,
                 createdAt = LocalDateTime.now(),
             )

--- a/src/test/kotlin/no/nav/syfo/api/SykepengerMaxDateRestV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/api/SykepengerMaxDateRestV1Test.kt
@@ -44,6 +44,7 @@ class SykepengerMaxDateRestV1Test :
             it("Should return formatted for letter max date with isoformat false") {
                 val maxDate = LocalDate.now().plusDays(30)
                 val utbetaltTom = LocalDate.now().plusDays(20)
+                val tom = LocalDate.now().plusDays(25)
 
                 every { tokenValidator.validateTokenXClaims().getFnr() } returns fnr
                 every { utbetalingerDAO.fetchMaksDatoByFnr(fnr) } returns
@@ -52,7 +53,7 @@ class SykepengerMaxDateRestV1Test :
                         fnr = fnr,
                         forelopig_beregnet_slutt = maxDate,
                         utbetalt_tom = utbetaltTom,
-                        tom = utbetaltTom,
+                        tom = tom,
                         gjenstaende_sykedager = "30",
                         opprettet = LocalDateTime.now().minusDays(60),
                     )
@@ -63,13 +64,14 @@ class SykepengerMaxDateRestV1Test :
                 val response = controller.getMaxDateInfo(isoformat = "false")
 
                 TestCase.assertEquals(formatDateForLetter(maxDate), response?.maxDate)
-                TestCase.assertEquals(formatDateForLetter(utbetaltTom), response?.utbetaltTom)
+                TestCase.assertEquals(formatDateForLetter(tom), response?.utbetaltTom)
             }
         }
 
         it("Should return raw max date with isoformat true") {
             val maxDate = LocalDate.now().plusDays(30)
             val utbetaltTom = LocalDate.now().plusDays(20)
+            val tom = LocalDate.now().plusDays(25)
 
             every { tokenValidator.validateTokenXClaims().getFnr() } returns fnr
             every { utbetalingerDAO.fetchMaksDatoByFnr(fnr) } returns
@@ -78,7 +80,7 @@ class SykepengerMaxDateRestV1Test :
                     fnr = fnr,
                     forelopig_beregnet_slutt = maxDate,
                     utbetalt_tom = utbetaltTom,
-                    tom = utbetaltTom,
+                    tom = tom,
                     gjenstaende_sykedager = "30",
                     opprettet = LocalDateTime.now().minusDays(60),
                 )
@@ -89,6 +91,6 @@ class SykepengerMaxDateRestV1Test :
             val response = controller.getMaxDateInfo(isoformat = "true")
 
             TestCase.assertEquals(maxDate.toString(), response?.maxDate)
-            TestCase.assertEquals(utbetaltTom.toString(), response?.utbetaltTom)
+            TestCase.assertEquals(tom.toString(), response?.utbetaltTom)
         }
     })


### PR DESCRIPTION
Ser at det i noen tilfeller kommer gamle datoer for `utbetalt_tom` (antakelig siden gamle sykepengesøknader kommer på nytt på topic fra Spleis). Dette vil antakelig rette seg etterhvert som nyere sykepengesøknader blir behandlet, men i mellomtiden er det antakelig fornuftig å defaulte til `tom`-datoen for `meroppfolging-backend`. Da vil `meroppfolging-backend` få akkurat de samme data'ene som den har pleid å få.

For `SykepengerMaxDateAzureApiV2` håndterer Modia at det kommer gamle datoer for `utbetalt_tom`, så den koden tilpasses ikke her.

`SykepengerMaxDateAzureApiV1` er ikke i bruk og kan egentlig slettes.