### PR TITLE
fix(deps): bump Spring Boot 3.5.13 and Tomcat 10.1.54

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 plugins {
     id("org.springframework.boot") version "3.5.13"
     id("io.spring.dependency-management") version "1.1.7"
-    kotlin("jvm") version "2.3.20"
-    kotlin("plugin.spring") version "2.3.20"
+    kotlin("jvm") version "2.3.10"
+    kotlin("plugin.spring") version "2.3.10"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
-    id("org.springframework.boot") version "3.5.11"
+    id("org.springframework.boot") version "3.5.13"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("jvm") version "2.3.20"
     kotlin("plugin.spring") version "2.3.20"
@@ -11,6 +11,8 @@ plugins {
 
 group = "no.nav.syfo"
 version = "0.0.1-SNAPSHOT"
+
+extra["tomcat.version"] = "10.1.54"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
Resolves critical CVEs in tomcat-embed-core:
- CVE-2026-29146 (Important): EncryptInterceptor padding oracle
- CVE-2026-34486 (Important): EncryptInterceptor bypass regression
- CVE-2026-32990 (Moderate): SNI hostname case bypass
- CVE-2026-29145 (Moderate): OCSP soft-fail bypass
- CVE-2026-25854 (Low): Open redirect
- CVE-2026-24880 (Low): Request smuggling
- CVE-2026-29129 (Low): TLS cipher order

Spring Boot 3.5.11 -> 3.5.13 (ships Tomcat 10.1.53) Tomcat override 10.1.53 -> 10.1.54 (full patch coverage)

<!-- Managed by esyfo-cli. Do not edit manually. Changes will be overwritten.
     For repo-specific customizations, create your own files without this header. -->
## Beskrivelse

<!-- Hva gjør denne PR-en og hvorfor? -->

## Endringer

<!-- - `fil/modul`: Hva som ble endret -->

## Issue

<!-- Closes #NUMMER / Relates to #NUMMER -->

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [ ] Ingen sensitiv data eksponert (tokens, credentials, PII)
