### PR TITLE
build(deps): upgrade vulnerable runtime dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,8 @@ plugins {
 group = "no.nav.syfo"
 version = "0.0.1-SNAPSHOT"
 
-extra["tomcat.version"] = "10.1.54"
+extra["tomcat.version"] = "10.1.55"
+extra["netty.version"] = "4.1.133.Final"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## Beskrivelse

Oppdaterer runtime dependency-overrides for å lukke Google Cloud CVE-funn for Tomcat og Netty uten å hoppe til større dependency-linjer.

## Endringer

- `build.gradle.kts`: oppgraderer `tomcat.version` fra `10.1.54` til `10.1.55`
- `build.gradle.kts`: legger til `netty.version = 4.1.133.Final`

## Issue

Ingen issue. Gjelder kritiske sårbarhetsfunn fra Google Cloud scanner.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil (`./gradlew --no-daemon build`)
- [x] Endringene er testet med `dependencyInsight` for `tomcat-embed-core`, `netty-codec-http` og `netty-codec-dns`
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)