### PR TITLE
fix(deps): bump netty.version to 4.1.135.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ group = "no.nav.syfo"
 version = "0.0.1-SNAPSHOT"
 
 extra["tomcat.version"] = "10.1.55"
-extra["netty.version"] = "4.1.133.Final"
+extra["netty.version"] = "4.1.135.Final"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## Beskrivelse

Oppgraderer `netty.version` fra `4.1.133.Final` til `4.1.135.Final` for å ta inn patchen for de rapporterte Netty-sårbarhetene i `netty-resolver-dns`.

## Endringer

- `build.gradle.kts`: oppdatert `extra["netty.version"]` til `4.1.135.Final`

## Issue

Ingen tilknyttet issue. Endringen gjøres for å lukke rapporterte CVE-er i avhengighetstreet.

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
